### PR TITLE
Add specific handling of notnull columns that have empty defaults to solve migration issues

### DIFF
--- a/src/Driver/AbstractDB2Driver.php
+++ b/src/Driver/AbstractDB2Driver.php
@@ -21,9 +21,9 @@ namespace DoctrineDbalIbmi\Driver;
 
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Platforms\DB2Platform;
-use Doctrine\DBAL\Schema\DB2SchemaManager;
 use DoctrineDbalIbmi\Platform\DB2IBMiPlatform;
 use DoctrineDbalIbmi\Schema\DB2IBMiSchemaManager;
+use DoctrineDbalIbmi\Schema\DB2LUWSchemaManager;
 
 /**
  * Abstract base implementation of the {@link Doctrine\DBAL\Driver} interface for IBM DB2 based drivers.
@@ -68,7 +68,7 @@ abstract class AbstractDB2Driver implements Driver
         if (PHP_OS === static::SYSTEM_IBMI) {
             return new DB2IBMiSchemaManager($conn);
         } else {
-            return new DB2SchemaManager($conn);
+            return new DB2LUWSchemaManager($conn);
         }
     }
 }

--- a/src/Schema/DB2IBMiSchemaManager.php
+++ b/src/Schema/DB2IBMiSchemaManager.php
@@ -20,7 +20,6 @@
 namespace DoctrineDbalIbmi\Schema;
 
 use Doctrine\DBAL\Schema\Column;
-use Doctrine\DBAL\Schema\DB2SchemaManager;
 use Doctrine\DBAL\Types\Type;
 
 /**
@@ -31,7 +30,7 @@ use Doctrine\DBAL\Types\Type;
  * @author Cassiano Vailati <c.vailati@esconsulting.it>
  * @author James Titcumb <james@asgrim.com>
  */
-class DB2IBMiSchemaManager extends DB2SchemaManager
+class DB2IBMiSchemaManager extends DB2LUWSchemaManager
 {
     /**
      * {@inheritdoc}

--- a/src/Schema/DB2LUWSchemaManager.php
+++ b/src/Schema/DB2LUWSchemaManager.php
@@ -1,0 +1,41 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace DoctrineDbalIbmi\Schema;
+
+use Doctrine\DBAL\Schema\DB2SchemaManager;
+
+/**
+ * DB2 LUW Schema Manager tweaks
+ *
+ * @author James Titcumb <james@asgrim.com>
+ */
+class DB2LUWSchemaManager extends DB2SchemaManager
+{
+    protected function _getPortableTableColumnDefinition($tableColumn)
+    {
+        $columnDefinition = parent::_getPortableTableColumnDefinition($tableColumn);
+
+        if ($columnDefinition->getNotnull() === true && empty($columnDefinition->getDefault())) {
+            $columnDefinition->setDefault(null);
+        }
+
+        return $columnDefinition;
+    }
+}


### PR DESCRIPTION
Migrations comparator was giving us false positives because notnull handling is weird in DB2.