### PR TITLE
[Fix] Notice: Undefined index: VAL

### DIFF
--- a/src/Driver/DB2IBMiConnection.php
+++ b/src/Driver/DB2IBMiConnection.php
@@ -40,7 +40,7 @@ class DB2IBMiConnection extends DB2Connection
 
         $res = $stmt->fetch();
 
-        return $res['VAL'];
+        return $res['val'];
     }
 
     /**


### PR DESCRIPTION
Lowercasing the index fixed the Notice on our IBMi server.
`var_dump($res)`

> array(2) {
>   ["val"]=>
>   string(1) "3"
>   [0]=>
>   string(1) "3"
> }