### PR TITLE
Support PHP_OS of OS400 & tweak doModifyLimitQuery

### DIFF
--- a/src/Driver/AbstractDB2Driver.php
+++ b/src/Driver/AbstractDB2Driver.php
@@ -11,6 +11,12 @@ use DoctrineDbalIbmi\Schema\DB2LUWSchemaManager;
 abstract class AbstractDB2Driver implements Driver
 {
     const SYSTEM_IBMI = 'AIX';
+    const SYSTEM_IBMI_OS400 = 'OS400';
+
+    public static function isIbmi()
+    {
+        return (PHP_OS === static::SYSTEM_IBMI || PHP_OS === static::SYSTEM_IBMI_OS400);
+    }
 
     /**
      * {@inheritdoc}
@@ -27,7 +33,7 @@ abstract class AbstractDB2Driver implements Driver
      */
     public function getDatabasePlatform()
     {
-        if (PHP_OS === static::SYSTEM_IBMI) {
+        if (static::isIbmi()) {
             return new DB2IBMiPlatform();
         } else {
             return new DB2Platform();
@@ -39,7 +45,7 @@ abstract class AbstractDB2Driver implements Driver
      */
     public function getSchemaManager(\Doctrine\DBAL\Connection $conn)
     {
-        if (PHP_OS === static::SYSTEM_IBMI) {
+        if (static::isIbmi()) {
             return new DB2IBMiSchemaManager($conn);
         } else {
             return new DB2LUWSchemaManager($conn);

--- a/src/Driver/DB2Driver.php
+++ b/src/Driver/DB2Driver.php
@@ -31,7 +31,7 @@ class DB2Driver extends AbstractDB2Driver
             $password = null;
         }
 
-        if (PHP_OS === static::SYSTEM_IBMI) {
+        if (static::isIbmi()) {
             return new DB2IBMiConnection($params, $username, $password, $driverOptions);
         } else {
             return new DB2Connection($params, $username, $password, $driverOptions);

--- a/src/Platform/DB2IBMiPlatform.php
+++ b/src/Platform/DB2IBMiPlatform.php
@@ -219,7 +219,7 @@ class DB2IBMiPlatform extends DB2Platform
      */
     protected function doModifyLimitQuery($query, $limit, $offset = null)
     {
-        if ($limit === null && $offset === null) {
+        if ($limit === null && $offset <= 0) {
             return $query;
         }
 


### PR DESCRIPTION
* If `PHP_OS` is `OS400` then select IBM i.
* Allow for case where `$limit = null` and `$offset = 0` in `doModifyLimitQuery()` as later DBALs convert `$offset` to an integer.